### PR TITLE
Add support for colorized JSON output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/cube2222/jql
 go 1.13
 
 require (
+	github.com/fatih/color v1.9.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/nwidger/jsoncolor v0.2.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
Add support for colorized JSON output via the
github.com/nwidger/jsoncolor package.  Colorized output can be
disabled via a new --monochrome flag.